### PR TITLE
Generate index file exposing functions before publishing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "scripts": {
     "test": "jest",
-    "lint": "eslint . --ext=.js,.mjs"
+    "lint": "eslint . --ext=.js,.mjs",
+    "prepack": "node ./scripts/generate-index.js",
+    "prepublish": "node ./scripts/generate-index.js"
   },
   "jest": {
     "transform": {

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+
+const INDEX_FILE_PATH = 'index.mjs';
+const FUNCTIONS_DIRECTORY = './functions';
+
+const stream = fs.createWriteStream(INDEX_FILE_PATH);
+const files = fs.readdirSync(FUNCTIONS_DIRECTORY);
+
+stream.once('open', () => {
+  console.log(`Generating: ${INDEX_FILE_PATH}`);
+  files.forEach(file => {
+    const { name } = path.parse(file);
+    console.log(`Adding: ${name}`);
+    stream.write(`export { default as ${name} } from '${FUNCTIONS_DIRECTORY}/${name}';\n`);
+  });
+  stream.end();
+});


### PR DESCRIPTION
A simple (and pretty dumb) script that generates an index file. Tried both [create-index](https://github.com/gajus/create-index) and [indexr](https://github.com/ryardley/indexr), but was unable to get to the result we need.

It takes the filename as exported function, which should be fine for now. As you can see there's no diff between the handmade version and the generated one 👍 

```shell
Generating: index.mjs
Adding: closest
Adding: compose
Adding: curry
Adding: debounce
Adding: head
Adding: map
Adding: not
Adding: preventDefault
Adding: preventingDefault
Adding: prop
Adding: tail
Adding: tap
Adding: throttle
```

PS: it runs on both `prepack` and `prepublish` since Yarn does not appear to work properly with `prepare` when publishing. This should work for both Yarn and npm.