### PR TITLE
Implement debounce using promises

### DIFF
--- a/functions/debounce.mjs
+++ b/functions/debounce.mjs
@@ -2,15 +2,19 @@
 import curry from './curry';
 
 /**
- * debounce :: (a -> b) -> Number -> (a -> b)
+ * debounce :: (a -> b) -> Number -> (a -> Promise b)
  */
-const debounce = curry((fn, delay) => {
-  let timer;
-  return function (...args) {
-    const context = this;
-    clearTimeout(timer);
-    timer = setTimeout(() => fn.apply(context, args), delay);
-  };
-});
+const debounce = curry(
+  (fn, delay) => {
+    let timer;
+    return function (...args) {
+      return new Promise((resolve) => {
+        const context = this;
+        clearTimeout(timer);
+        timer = setTimeout(() => resolve(fn.apply(context, args)), delay);
+      });
+    };
+  }
+);
 
 export default debounce;

--- a/test/debounce.test.js
+++ b/test/debounce.test.js
@@ -5,18 +5,22 @@ describe('debounce', () => {
   let debouncedFn;
 
   beforeEach(() => {
-    fn = jest.fn();
+    fn = jest.fn(() => 42);
     debouncedFn = debounce(fn, 1000);
   });
 
   jest.useFakeTimers();
 
   test('Should debounce function calls', () => {
-    debouncedFn();
+    expect.assertions(3);
+
+    const promise = debouncedFn().then(x => expect(x).toEqual(42));
+
     expect(fn).toHaveBeenCalledTimes(0);
 
     jest.runAllTimers();
     expect(fn).toHaveBeenCalledTimes(1);
+    return promise;
   });
 
   test('Should only call it once', () => {


### PR DESCRIPTION
By turning debounce into a Promise returning function, you can actually
use the return value of the debounced function.

Example usage:

```js
const getWindowDimensions = debounce(() => { /* ... */ });

const resizeListener = async e => {
  const windowDimensions = await getWindowDimensions();
  
  // re-paint the interface or whatever
};

window.addEventListener('resize', resizeListener);
```

What do you think?