### PR TITLE
Add memoize function

### DIFF
--- a/functions/memoize.js
+++ b/functions/memoize.js
@@ -1,0 +1,18 @@
+import curry from './curry';
+
+/**
+ * Store results of function calls and return the cache when input arguments
+ * are the same;
+ */
+const memoize = curry(fn => {
+  const cache = {};
+  return (...args) => {
+    const key = JSON.stringify(args);
+    if (!(key in cache)) {
+      cache[key] = fn(...args);
+    }
+    return cache[key];
+  };
+});
+
+export default memoize;

--- a/test/memoize.test.js
+++ b/test/memoize.test.js
@@ -1,0 +1,37 @@
+import memoize from '../functions/memoize';
+
+describe('memoize', () => {
+  test('Memoizes functions', () => {
+    const add = jest.fn((x, y) => x + y);
+    const memoizedAdd = memoize(add);
+
+    memoize(add(1, 2));
+    memoize(add(1, 2));
+    expect(add).toHaveBeenCalledTimes(2);
+
+    memoizedAdd(1, 2);
+    memoizedAdd(1, 2);
+    expect(add).toHaveBeenCalledTimes(3);
+
+    expect(add(1, 2)).toEqual(3);
+    expect(memoizedAdd(1, 2)).toEqual(3);
+
+    const fn = jest.fn(({ a, b }) => a === b);
+    const memoizedFn = memoize(fn);
+
+    memoizedFn({ a: true, b: true });
+    memoizedFn({ a: true, b: true });
+    expect(fn).toHaveLastReturnedWith(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    memoizedFn({ a: true, b: false });
+    memoizedFn({ a: true, b: false });
+    expect(fn).toHaveLastReturnedWith(false);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    memoizedFn({ a: false, b: false });
+    memoizedFn({ a: false, b: false });
+    expect(fn).toHaveLastReturnedWith(true);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
Probably the most simple form of memoization. I've built the function myself, since a lot of (simple) examples only took one argument or checked for stuff like `if (!cache[key])`, which is weird because falsey returns would never be cached (right?).

Please let me know if you'd like to see this function differently or would improve anything 👋 