### PR TITLE
Add reverse, last, take, takeLast functions

### DIFF
--- a/functions/last.mjs
+++ b/functions/last.mjs
@@ -1,0 +1,6 @@
+/**
+ * Grab the last item of a collection.
+ */
+const last = xs => xs[xs.length - 1];
+
+export default last;

--- a/functions/reverse.mjs
+++ b/functions/reverse.mjs
@@ -1,0 +1,6 @@
+/**
+ * Return a reversed array.
+ */
+const reverse = ([x, ...xs]) => x ? [...reverse(xs), x] : [];
+
+export default reverse;

--- a/functions/take.mjs
+++ b/functions/take.mjs
@@ -1,0 +1,8 @@
+import curry from './curry';
+
+/**
+ * Grab the first n items of a collection.
+ */
+const take = curry((n, [x, ...xs]) => x && n ? [x, ...take(n - 1, xs)] : []);
+
+export default take;

--- a/functions/takeLast.mjs
+++ b/functions/takeLast.mjs
@@ -1,0 +1,12 @@
+import curry from './curry';
+
+/**
+ * Grab the last n items of a collection.
+ */
+const takeLast = curry((n, xs) => n > xs.length
+  ? [...xs]
+  : n
+    ? [xs[xs.length - n], ...takeLast(n - 1, xs)]
+    : []);
+
+export default takeLast;

--- a/test/last.test.js
+++ b/test/last.test.js
@@ -1,0 +1,12 @@
+import last from '../functions/last';
+
+describe('last', () => {
+  test('Should grab the last of an array', () => {
+    expect(last(['foo', 'bar', 'baz'])).toEqual('baz');
+    expect(last([])).toBeUndefined();
+  });
+  test('Should grab the last character of a string', () => {
+    expect(last('Boo')).toEqual('o');
+    expect(last('')).toBeUndefined();
+  });
+});

--- a/test/reverse.test.js
+++ b/test/reverse.test.js
@@ -1,0 +1,12 @@
+import reverse from '../functions/reverse';
+
+describe('reverse', () => {
+  test('Should reverse an array', () => {
+    expect(reverse(['foo', 'bar', 'baz'])).toEqual(['baz', 'bar', 'foo']);
+    expect(reverse([])).toEqual([]);
+  });
+  test('Should reverse a string', () => {
+    expect(reverse('foo bar')).toEqual(['r', 'a', 'b', ' ', 'o', 'o', 'f']);
+    expect(reverse('')).toEqual([]);
+  });
+});

--- a/test/take.test.js
+++ b/test/take.test.js
@@ -1,0 +1,14 @@
+import take from '../functions/take';
+
+describe('take', () => {
+  test('Should get the first n items of an array', () => {
+    expect(take(2, ['foo', 'bar', 'baz'])).toEqual(['foo', 'bar']);
+    expect(take(8, ['foo', 'bar', 'baz'])).toEqual(['foo', 'bar', 'baz']);
+    expect(take(2, [])).toEqual([]);
+    expect(take(2)(['foo', 'bar', 'baz'])).toEqual(['foo', 'bar']);
+  });
+  test('Should get the first n items of a string', () => {
+    expect(take(4, 'foo bar')).toEqual(['f', 'o', 'o', ' ']);
+    expect(take(4, '')).toEqual([]);
+  });
+});

--- a/test/takeLast.test.js
+++ b/test/takeLast.test.js
@@ -1,0 +1,14 @@
+import takeLast from '../functions/takeLast';
+
+describe('takeLast', () => {
+  test('Should get the first n items of an array', () => {
+    expect(takeLast(2, ['foo', 'bar', 'baz'])).toEqual(['bar', 'baz']);
+    expect(takeLast(2, [])).toEqual([]);
+    expect(takeLast(8, ['foo', 'bar', 'baz'])).toEqual(['foo', 'bar', 'baz']);
+    expect(takeLast(2)(['foo', 'bar', 'baz'])).toEqual(['bar', 'baz']);
+  });
+  test('Should get the first n items of a string', () => {
+    expect(takeLast(4, 'foo bar')).toEqual([' ', 'b', 'a', 'r']);
+    expect(takeLast(4, '')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Added `first`, `last` and `reverse` functions. Would like to discuss how one could handle a curried function with an argument default. Removing the default or not making it curried would solve the issue, but both are quite practical ¯\_(ツ)_/¯

Commented out the curried parts; all feedback is welcome/helpful 👍 