### PR TITLE
Add defined function

### DIFF
--- a/functions/defined.mjs
+++ b/functions/defined.mjs
@@ -1,0 +1,6 @@
+/**
+ * Check if argument is defined.
+ */
+const defined = x => typeof x !== 'undefined';
+
+export default defined;

--- a/test/defined.test.js
+++ b/test/defined.test.js
@@ -1,0 +1,16 @@
+import defined from '../functions/defined';
+
+describe('defined', () => {
+  test('Should check if defined', () => {
+    const bar = 'baz';
+    expect(defined(bar)).toBeTruthy();
+    expect(defined([])).toBeTruthy();
+    expect(defined('')).toBeTruthy();
+
+    let foo;
+    expect(foo).toBeUndefined();
+    expect(defined(foo)).toBeFalsy();
+    expect(defined(window.bar)).toBeFalsy();
+    expect(defined(undefined)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Initially added a `undefined` function as well, and renamed it all to `def`/`undef`, but I think having only a `defined` function is more clear (and all you need). 

Feedback is welcome.