### PR TITLE
Add htmlToElement and unescapeHtml functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "no-confusing-arrow": 0,
     "no-nested-ternary": 0,
     "implicit-arrow-linebreak": 0,
-    "arrow-body-style": 0
+    "arrow-body-style": 0,
+    "quotes": 0,
   }
 }

--- a/functions/htmlToElement.mjs
+++ b/functions/htmlToElement.mjs
@@ -1,0 +1,10 @@
+/**
+ * Convert HTML string to DOM element.
+ */
+const htmlToElement = html => {
+  const placeholder = document.createElement('div');
+  placeholder.innerHTML = html;
+  return placeholder.children.length ? placeholder.firstElementChild : undefined;
+};
+
+export default htmlToElement;

--- a/functions/unescapeHtml.mjs
+++ b/functions/unescapeHtml.mjs
@@ -1,0 +1,10 @@
+/**
+ * Unescapes HTML.
+ */
+const unescapeHtml = html => {
+  const text = document.createElement('textarea');
+  text.innerHTML = html;
+  return text.value;
+};
+
+export default unescapeHtml;

--- a/test/htmlToElement.test.js
+++ b/test/htmlToElement.test.js
@@ -1,0 +1,12 @@
+import htmlToElement from '../functions/htmlToElement';
+
+describe('htmlToElement', () => {
+  test('Converts a string to DOM node.', () => {
+    const template = `<button id="button">Click me</button>`;
+    const button = htmlToElement(template);
+    document.body.appendChild(button);
+
+    expect(button).toEqual(document.querySelector('#button'));
+    expect(htmlToElement('none')).toBeUndefined();
+  });
+});

--- a/test/unescapeHtml.test.js
+++ b/test/unescapeHtml.test.js
@@ -1,0 +1,12 @@
+import unescapeHtml from '../functions/unescapeHtml';
+
+describe('unescapeHtml', () => {
+  test('Unescapes HTML.', () => {
+    const escapedTemplate = `&lt;button id=&#34;button&#34;&gt;Click me&lt;/button&gt;`;
+    const unescapedTemplate = `<button id="button">Click me</button>`;
+
+    expect(unescapeHtml(escapedTemplate)).toEqual(unescapedTemplate);
+    expect(unescapeHtml(unescapedTemplate)).toEqual(unescapedTemplate);
+    expect('').toEqual('');
+  });
+});


### PR DESCRIPTION
This is a simple function I've written and have been using a lot in recent projects. This allows you to do this...

```js
const button = htmlToElement(`
  <button class="foo" aria-hidden="true", aria-controls="bar"></button>
`);
```

... instead of this:

```js
const button = document.createElement('div');
button.classList.add('foo');
button.setAttribute('aria-hidden', 'true');
button.setAttribute('aria-controls', 'bar');
```

---

Some notes and questions:

- Is this the right name? A lot of names are possible... `stringToElement`, `stringToDomNode`, `templateToElement`, ... (I think `template` is too generic)
- It can also convert `htmlspecialchars` when taken from a data-attribute for example; had to use it before, makes sense, right?
- This only returns one element, was thinking about creating a plural version and returning an array of element using this function (`<button></button><button></button>` => `[button, button]`).