### PR TITLE
Add uuid function

### DIFF
--- a/functions/uuid.mjs
+++ b/functions/uuid.mjs
@@ -1,0 +1,13 @@
+/* eslint-disable space-infix-ops, no-bitwise, no-mixed-operators */
+
+/**
+ * Generate RFC4122 v4 compliant UUID.
+ * See: https://stackoverflow.com/a/2117523
+ */
+const uuid = () => {
+  const crypto = window.crypto || window.msCrypto;
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16));
+};
+
+export default uuid;

--- a/test/uuid.test.js
+++ b/test/uuid.test.js
@@ -1,0 +1,19 @@
+import uuid from '../functions/uuid';
+
+// See https://stackoverflow.com/a/52612372
+const crypto = require('crypto');
+
+Object.defineProperty(global.self, 'crypto', {
+  value: {
+    getRandomValues: arr => crypto.randomBytes(arr.length),
+  },
+});
+
+describe('uuid', () => {
+  test('Should create a unique identifier', () => {
+    expect(uuid().length).toEqual(36);
+    for (let i = 0; i < 1000; i += 1) {
+      expect(uuid()).not.toEqual(uuid());
+    }
+  });
+});


### PR DESCRIPTION
Generates RFC4122 compliant UUID. Works in IE11 and all modern browsers. 

Have been using this a lot for accessible templates or modules which can exist multiple times on a page (e.g. `aria-controls="tabs-32849b69-9e19-4cc0-9736-a2be00db8ee8-panel-1"`).