### PR TITLE
Debounce throttle redux

### DIFF
--- a/functions/debounce.mjs
+++ b/functions/debounce.mjs
@@ -1,14 +1,5 @@
 /* eslint-disable func-names */
 import curry from './curry';
-import memoize from './memoize';
-
-const setTimer = memoize(() => {
-  let timer;
-  return (fn, delay) => {
-    clearTimeout(timer);
-    timer = setTimeout(fn, delay);
-  };
-});
 
 /**
  * Creates a debounced function that delays invoking {fn} until after {delay}
@@ -17,12 +8,14 @@ const setTimer = memoize(() => {
  */
 const debounce = curry(
   (fn, delay) => {
-    return memoize(function (...args) {
-      const context = this;
+    let timer;
+    return function (...args) {
       return new Promise((resolve) => {
-        setTimer(...args)(() => resolve(fn.apply(context, args)), delay);
+        const context = this;
+        clearTimeout(timer);
+        timer = setTimeout(() => resolve(fn.apply(context, args)), delay);
       });
-    });
+    };
   }
 );
 

--- a/functions/debounce.mjs
+++ b/functions/debounce.mjs
@@ -1,21 +1,28 @@
 /* eslint-disable func-names */
 import curry from './curry';
+import memoize from './memoize';
+
+const setTimer = memoize(() => {
+  let timer;
+  return (fn, delay) => {
+    clearTimeout(timer);
+    timer = setTimeout(fn, delay);
+  };
+});
 
 /**
- * Group function calls in a single delayed call after the last call.
- *
- * debounce :: (a -> b) -> Number -> (a -> Promise b)
+ * Creates a debounced function that delays invoking {fn} until after {delay}
+ * milliseconds have elapsed since the last time the debounced function was invoked.
+ * Returns a promise that resolves to the value returned by {fn}.
  */
 const debounce = curry(
   (fn, delay) => {
-    let timer;
-    return function (...args) {
+    return memoize(function (...args) {
+      const context = this;
       return new Promise((resolve) => {
-        const context = this;
-        clearTimeout(timer);
-        timer = setTimeout(() => resolve(fn.apply(context, args)), delay);
+        setTimer(...args)(() => resolve(fn.apply(context, args)), delay);
       });
-    };
+    });
   }
 );
 

--- a/test/debounce.test.js
+++ b/test/debounce.test.js
@@ -1,44 +1,55 @@
 import debounce from '../functions/debounce';
 
+const THRESHOLD = 1000;
+
 describe('debounce', () => {
   let fn;
   let debouncedFn;
 
   beforeEach(() => {
     fn = jest.fn((x) => x * 2);
-    debouncedFn = debounce(fn, 1000);
+    debouncedFn = debounce(fn, THRESHOLD);
   });
 
   jest.useFakeTimers();
 
   test('Should debounce function calls', () => {
-    expect.assertions(3);
+    expect.assertions(6);
 
-    const promise = debouncedFn(21).then(x => expect(x).toEqual(42));
+    const promises = [
+      debouncedFn(21).then(x => expect(x).toEqual(42)),
+    ];
 
     expect(fn).toHaveBeenCalledTimes(0);
-
-    jest.runAllTimers();
+    jest.advanceTimersByTime(THRESHOLD);
     expect(fn).toHaveBeenCalledTimes(1);
-    return promise;
+
+    promises.push(debouncedFn(3).then(x => expect(x).toEqual(6)));
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(THRESHOLD);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    return Promise.all(promises);
   });
 
   test('Should only call it once', () => {
     let promise;
-    for (let i = 0; i < 100; i += 1) {
+    for (let i = 0; i < THRESHOLD; i += 1) {
       promise = debouncedFn();
       jest.advanceTimersByTime(1);
     }
-    expect(fn).toHaveBeenCalledTimes(0);
 
-    jest.runAllTimers();
+    expect(fn).toHaveBeenCalledTimes(0);
+    jest.advanceTimersByTime(THRESHOLD);
     expect(fn).toHaveBeenCalledTimes(1);
+
     return promise;
   });
 
   test('Should call function with given arguments', () => {
     debouncedFn('foo');
-    jest.runAllTimers();
+    jest.advanceTimersByTime(THRESHOLD);
     expect(fn).toHaveBeenCalledWith('foo');
   });
 });

--- a/test/debounce.test.js
+++ b/test/debounce.test.js
@@ -12,31 +12,28 @@ describe('debounce', () => {
   jest.useFakeTimers();
 
   test('Should debounce function calls', () => {
-    expect.assertions(4);
+    expect.assertions(3);
 
-    const promises = [
-      debouncedFn(21).then(x => expect(x).toEqual(42)),
-      debouncedFn(200).then(x => expect(x).toEqual(400)),
-    ];
+    const promise = debouncedFn(21).then(x => expect(x).toEqual(42));
 
     expect(fn).toHaveBeenCalledTimes(0);
 
     jest.runAllTimers();
-    expect(fn).toHaveBeenCalledTimes(2);
-    return Promise.all(promises);
+    expect(fn).toHaveBeenCalledTimes(1);
+    return promise;
   });
 
   test('Should only call it once', () => {
-    const promises = [];
+    let promise;
     for (let i = 0; i < 100; i += 1) {
-      promises.push(debouncedFn());
+      promise = debouncedFn();
       jest.advanceTimersByTime(1);
     }
     expect(fn).toHaveBeenCalledTimes(0);
 
     jest.runAllTimers();
     expect(fn).toHaveBeenCalledTimes(1);
-    return Promise.all(promises);
+    return promise;
   });
 
   test('Should call function with given arguments', () => {

--- a/test/debounce.test.js
+++ b/test/debounce.test.js
@@ -5,33 +5,38 @@ describe('debounce', () => {
   let debouncedFn;
 
   beforeEach(() => {
-    fn = jest.fn(() => 42);
+    fn = jest.fn((x) => x * 2);
     debouncedFn = debounce(fn, 1000);
   });
 
   jest.useFakeTimers();
 
   test('Should debounce function calls', () => {
-    expect.assertions(3);
+    expect.assertions(4);
 
-    const promise = debouncedFn().then(x => expect(x).toEqual(42));
+    const promises = [
+      debouncedFn(21).then(x => expect(x).toEqual(42)),
+      debouncedFn(200).then(x => expect(x).toEqual(400)),
+    ];
 
     expect(fn).toHaveBeenCalledTimes(0);
 
     jest.runAllTimers();
-    expect(fn).toHaveBeenCalledTimes(1);
-    return promise;
+    expect(fn).toHaveBeenCalledTimes(2);
+    return Promise.all(promises);
   });
 
   test('Should only call it once', () => {
+    const promises = [];
     for (let i = 0; i < 100; i += 1) {
-      debouncedFn();
+      promises.push(debouncedFn());
       jest.advanceTimersByTime(1);
     }
     expect(fn).toHaveBeenCalledTimes(0);
 
     jest.runAllTimers();
     expect(fn).toHaveBeenCalledTimes(1);
+    return Promise.all(promises);
   });
 
   test('Should call function with given arguments', () => {

--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -7,23 +7,32 @@ describe('throttle', () => {
   let throttledFn;
 
   beforeEach(() => {
-    fn = jest.fn();
+    fn = jest.fn((x) => x * 2);
     throttledFn = throttle(fn, THRESHOLD);
   });
 
   jest.useFakeTimers();
 
   test('Should invoke function immediately', () => {
-    throttledFn();
-    expect(fn).toHaveBeenCalledTimes(1);
+    expect.assertions(3);
+    const promises = [
+      throttledFn(21).then(x => expect(x).toEqual(42)),
+      throttledFn(200).then(x => expect(x).toEqual(400)),
+    ];
+    expect(fn).toHaveBeenCalledTimes(2);
+    return Promise.all(promises);
   });
 
   test('Should throttle function calls', () => {
-    for (let i = 0; i < THRESHOLD * 10; i += THRESHOLD) {
-      throttledFn();
+    expect.assertions(21);
+    const promises = [];
+    for (let i = 0; i < 10; i += 1) {
+      promises.push(throttledFn(21).then(x => expect(x).toEqual(42)));
+      promises.push(throttledFn(200).then(x => expect(x).toEqual(400)));
       jest.advanceTimersByTime(THRESHOLD);
     }
-    expect(fn).toHaveBeenCalledTimes(10);
+    expect(fn).toHaveBeenCalledTimes(20);
+    return Promise.all(promises);
   });
 
   test('Should call function with given arguments', () => {


### PR DESCRIPTION
This update allows `debounce` to be called multiple times with different
arguments.

`debounce(foo)(200)` will be its own debounced invocation stack, distinct
from `debounce(foo)(100)`.

Also: in the previous implementation, multiple calls would result in
multiple promises, but most would be left hanging: only the last promise
would resolve.

This implementation ensures all promises resolve, *however*, the
promises will all get the same value from the debounced function call.

Example: https://codepen.io/harmenjanssen/pen/qvZyqr?editors=0011

--- 

`throttle` has been refactored similarly to `debounce`: it will return a
promise, and memoize on arguments.

This means two separate `throttle` calls are throttled independently based
on its arguments.