### PR TITLE
Add DocumentFragment to disallowed node types in closest function

### DIFF
--- a/functions/closest.mjs
+++ b/functions/closest.mjs
@@ -5,7 +5,7 @@ import curry from './curry';
  * matching the predicate function.
  */
 const closest = curry((predicate, node) =>
-  !node || node.nodeType === Node.DOCUMENT_NODE
+  !node || node.nodeType === Node.DOCUMENT_NODE || node.nodeType === Node.DOCUMENT_FRAGMENT_NODE
     ? undefined
     : predicate(node)
       ? node

--- a/test/closest.test.js
+++ b/test/closest.test.js
@@ -1,20 +1,22 @@
 import closest from '../functions/closest';
 
 describe('closest', () => {
+  const template = `
+    <article id="root-article">
+      <h1>My title</h1>
+      <p lang="la">Lorem ipsum dolor sit amet</p>
+      <footer>
+        <article id="footer-article">
+          <div lang="la" id="footer-div">
+            <p>Lorem ipsum dolor sit amet</p>
+          </div>
+        </article>
+      </footer>
+    </article>
+  `;
+
   test('Finds parent nodes, or itself whenever it matches the predicate.', () => {
-    document.body.innerHTML = `
-      <article id="root-article">
-        <h1>My title</h1>
-        <p lang="la">Lorem ipsum dolor sit amet</p>
-        <footer>
-          <article id="footer-article">
-            <div lang="la" id="footer-div">
-              <p>Lorem ipsum dolor sit amet</p>
-            </div>
-          </article>
-        </footer>
-      </article>
-    `;
+    document.body.innerHTML = template;
 
     expect(closest(x => x.hasAttribute('id'), document.querySelector('footer')))
       .toEqual(document.querySelector('#root-article'));
@@ -29,6 +31,21 @@ describe('closest', () => {
       .toBeUndefined();
 
     expect(closest(x => x, document.getElementById('none')))
+      .toBeUndefined();
+  });
+
+  test('Does not traverse up to document nodes.', () => {
+    const fragment = document.createDocumentFragment();
+    const placeholder = document.createElement('div');
+
+    document.body.innerHTML = template;
+    placeholder.innerHTML = template;
+    fragment.appendChild(placeholder);
+
+    expect(closest(x => x.hasAttribute('none'), document.querySelector('article')))
+      .toBeUndefined();
+
+    expect(closest(x => x.hasAttribute('none'), fragment.querySelector('article')))
       .toBeUndefined();
   });
 });


### PR DESCRIPTION
It's messing with the `findElementWithHandler` in `@grrr/hansel`, since a DocumentFragment doesn't have the `hasAttribute` method. I think you can't traverse up more than the fragment itself, since else it would've been appended to the actual DOM, right? And then it's not a fragment anymore...