### PR TITLE
Add escapeHtml function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ A grouped list of functions based on their origin/usage.
 ### DOM & Browser
 
 - [closest](#closest)
+- [escapeHtml](#escapeHtml)
 - [htmlToElement](#htmlToElement)
 - [preventDefault](#preventDefault)
 - [preventingDefault](#preventingDefault)
@@ -112,6 +113,17 @@ const bar = [];
 
 defined(foo); //=> false
 defined(bar); //=> true
+```
+
+### escapeHtml
+
+Escapes HTML. Useful for sanitizing user input to prevent XSS attacks.
+
+See also [unescapeHtml](#unescapeHtml).
+
+```js
+const html = `"><img src=/ onerror="alert('XSS')"></img>`;
+escapeHtml(html) //=> &quot;&gt;&lt;img src=/ onerror=&quot;alert(&#039;XSS&#039;)&quot;&gt;&lt;/img&gt;
 ```
 
 ### head
@@ -330,6 +342,8 @@ focusTrap.retrap(); // retraps focus again (initial nodes only)
 ### unescapeHtml
 
 Unescapes HTML.
+
+See also [escapeHtml](#escapeHtml).
 
 ```js
 const html = `&lt;button id=&#34;button&#34;&gt;Click me&lt;/button&gt;`;

--- a/functions/escapeHtml.mjs
+++ b/functions/escapeHtml.mjs
@@ -1,0 +1,19 @@
+/**
+ * Escapes HTML, used for sanitizing user input.
+ * Normally the preferred way to do so is by assigning those values with native
+ * JavaScript methods like `input.value` or `node.textContent`. However, when a
+ * complete template is set via `innerHTML` or a similar method, user input needs
+ * to be escaped.
+ */
+const escapeHtml = (html, { quotes = true } = {}) => {
+  const textarea = document.createElement('textarea');
+  textarea.textContent = html;
+  return quotes
+    ? textarea.innerHTML
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;")
+      .replace(/`/g, "&grave;")
+    : textarea.innerHTML;
+};
+
+export default escapeHtml;

--- a/functions/unescapeHtml.mjs
+++ b/functions/unescapeHtml.mjs
@@ -2,9 +2,9 @@
  * Unescapes HTML.
  */
 const unescapeHtml = html => {
-  const text = document.createElement('textarea');
-  text.innerHTML = html;
-  return text.value;
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = html;
+  return textarea.textContent;
 };
 
 export default unescapeHtml;

--- a/index.mjs
+++ b/index.mjs
@@ -3,6 +3,7 @@ export { default as compose } from './functions/compose';
 export { default as curry } from './functions/curry';
 export { default as debounce } from './functions/debounce';
 export { default as defined } from './functions/defined';
+export { default as escapeHtml } from './functions/escapeHtml';
 export { default as head } from './functions/head';
 export { default as htmlToElement } from './functions/htmlToElement';
 export { default as last } from './functions/last';

--- a/test/escapeHtml.test.js
+++ b/test/escapeHtml.test.js
@@ -1,0 +1,15 @@
+import escapeHtml from '../functions/escapeHtml';
+
+describe('escapeHtml', () => {
+  test('Escapes HTML.', () => {
+    const unescapedTemplate = `"><img src=/ onerror="alert('XSS')"></img>`;
+    const escapedTemplateIncludingQuotes = `&quot;&gt;&lt;img src=/ onerror=&quot;alert(&#039;XSS&#039;)&quot;&gt;&lt;/img&gt;`;
+    const escapedTemplateExcludingQuotes = `"&gt;&lt;img src=/ onerror="alert('XSS')"&gt;&lt;/img&gt;`;
+
+    expect(escapeHtml(unescapedTemplate))
+      .toEqual(escapedTemplateIncludingQuotes);
+    expect(escapeHtml(unescapedTemplate, { quotes: false }))
+      .toEqual(escapedTemplateExcludingQuotes);
+    expect(escapeHtml('')).toEqual('');
+  });
+});

--- a/test/unescapeHtml.test.js
+++ b/test/unescapeHtml.test.js
@@ -7,6 +7,6 @@ describe('unescapeHtml', () => {
 
     expect(unescapeHtml(escapedTemplate)).toEqual(unescapedTemplate);
     expect(unescapeHtml(unescapedTemplate)).toEqual(unescapedTemplate);
-    expect('').toEqual('');
+    expect(unescapeHtml('')).toEqual('');
   });
 });


### PR DESCRIPTION
A simple method to escape HTML to prevent XSS and layout breaking issues (due to quotes being added in attributes). It's the reverse of the existing `unescapeHtml` method.

- ~~Haven't added tests + documentation yet~~, since I wanted to check the idea and implementation.
- The `textarea` methods provides a nice and clean way, but doesn't escape quotes by default. 
- I've added manual quote escaping, plus an option to turn it off. Not sure if needed, but felt nice to have? Had a `quotes` and `backticks` option first, but might be too much control?
- Small adjustment to `unescapeHtml`, shouldn't change behaviour.

Result:

```js
escapeHtml(`<p>Hello world..'"\` € <script>\\</p>`);  
  // => &lt;p&gt;Hello world..&#039;&quot;&grave; € &lt;script&gt;\&lt;/p&gt;
