### PR TITLE
Add triggerEvent function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ A grouped list of functions based on their origin/usage.
 - [preventDefault](#preventDefault)
 - [preventingDefault](#preventingDefault)
 - [trapFocus](#trapFocus)
+- [triggerEvent](#triggerEvent)
 - [unescapeHtml](#unescapeHtml)
 
 ### Misc
@@ -356,6 +357,23 @@ focusTrap.release(); // releases focus
 focusTrap.retrap(); // retraps focus again (initial nodes only)
 ```
 
+### triggerEvent
+
+Create and trigger a synthetic event ([new Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event) combined with [dispatchEvent](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent)).
+
+Useful when updating the value of HTML inputs, while maintaining existing `addEventListener` callback behaviour. Defaults to a bubbling and cancelable event, but allows optional [Event properties](https://developer.mozilla.org/en-US/docs/Web/API/Event#Properties) object as *third* argument.
+
+```js
+input.addEventListener('input', foo);
+input.value = 25;
+triggerEvent(input, 'input'); //=> `foo` is called
+
+// with another type of event and `Event` constructor arguments
+triggerEvent(input, 'blur', {
+  composed: false,
+});
+```
+
 ### unescapeHtml
 
 Unescapes HTML.
@@ -369,7 +387,7 @@ unescapeHtml(html) //=> <button id="button">Click me</button>
 
 ### uuid
 
-Generate RFC4122 v4 compliant UUID.
+Generate [RFC4122](https://tools.ietf.org/html/rfc4122) v4 compliant UUID.
 
 Handy for generating dynamic ids for accessible components used multiple times on a page.
 

--- a/functions/triggerEvent.js
+++ b/functions/triggerEvent.js
@@ -1,0 +1,18 @@
+/**
+ * Create and trigger programmatically created event (also known as 'synthetic event').
+ * We throw an error when the type is missing, to avoid failing silently.
+ */
+const triggerEvent = (node, type, options = {}) => {
+  if (!type) {
+    throw new Error('Missing event type name in triggerEvent.');
+  }
+  const e = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+    isTrusted: false,
+    ...options,
+  });
+  return node.dispatchEvent(e);
+};
+
+export default triggerEvent;

--- a/index.mjs
+++ b/index.mjs
@@ -25,5 +25,6 @@ export { default as takeLast } from './functions/takeLast';
 export { default as tap } from './functions/tap';
 export { default as throttle } from './functions/throttle';
 export { default as trapFocus } from './functions/trapFocus';
+export { default as triggerEvent } from './functions/triggerEvent';
 export { default as unescapeHtml } from './functions/unescapeHtml';
 export { default as uuid } from './functions/uuid';

--- a/test/triggerEvent.test.js
+++ b/test/triggerEvent.test.js
@@ -1,0 +1,40 @@
+import triggerEvent from '../functions/triggerEvent';
+
+describe('triggerEvent', () => {
+  test('Triggers synthetic event for the given input and event type', () => {
+    document.body.innerHTML = `
+      <input id="foo"/>
+      <input id="bar"/>
+    `;
+    const foo = document.querySelector('#foo');
+    const bar = document.querySelector('#bar');
+
+    const inputCallbackFoo = jest.fn();
+    const blurCallbackFoo = jest.fn();
+    const blurCallbackBar = jest.fn();
+
+    foo.addEventListener('input', inputCallbackFoo);
+    foo.addEventListener('blur', blurCallbackFoo);
+    bar.addEventListener('blur', blurCallbackBar);
+
+    triggerEvent(foo, 'input');
+    expect(inputCallbackFoo).toHaveBeenCalled();
+    expect(inputCallbackFoo.mock.calls.length).toBe(1);
+
+    triggerEvent(foo, 'blur');
+    expect(blurCallbackFoo).toHaveBeenCalled();
+    expect(blurCallbackFoo.mock.calls.length).toBe(1);
+
+    triggerEvent(foo, 'blur');
+    triggerEvent(foo, 'blur');
+    expect(inputCallbackFoo.mock.calls.length).toBe(1);
+    expect(blurCallbackFoo.mock.calls.length).toBe(3);
+    expect(blurCallbackBar).not.toHaveBeenCalled();
+
+    expect(() => triggerEvent(bar)).toThrow();
+    expect(blurCallbackBar).not.toHaveBeenCalled();
+
+    triggerEvent(bar, 'blur');
+    expect(blurCallbackBar.mock.calls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Hey! 👋  😄 

This is a utility function I've used regularly on recent projects, and I think it fits nicely into this library. Everything is up for discussion as always (or even better: improvement).

Acts as simplified wrapper with some opinionated but sane defaults:

```js
input.addEventListener('input', foo);
input.value = 25;
triggerEvent(input);
```

instead of...

```js
input.addEventListener('input', foo);
input.value = 25;

const inputEvent = new Event('input', { bubbles: true, cancelable: true });
input.dispatchEvent(inputEvent);
```

Notes:

- Defaults to the [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) event, which makes the most sense to me as default. Thoughts?
- I think construction a new `Event` on every `triggerEvent` call should be fine, can't imagine running into performance issues in real life. 
- Now arbitrarily returns the `dispatchEvent` call. Makes sense, but not fully sure...?