### PR TITLE
Update Ubuntu versions in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   ci:
     name: CI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -27,7 +27,7 @@ jobs:
 
   notification:
     name: Slack notification
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     needs: [ci]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grrr/utils",
   "version": "2.5.0",
-  "description": "Utility functions, by Grrr.",
+  "description": "JavaScript utility functions, by GRRR.",
   "main": "index.mjs",
   "author": "GRRR <npm@grrr.nl>",
   "homepage": "https://github.com/grrr-amsterdam/grrr-utils",


### PR DESCRIPTION
Trivial PR, but I just tried to import the published package, and bumped onto the issue of the the package still being published to npm without the `.mjs` extensions in the `index.mjs`.
Which in hindsight makes sense, since the auto generate function fixed in the previous PR locally created an incorrect bundle, which was then published...

If a new version could be published (`v2.5.1`), then all should be fixed & fine 😇🤞